### PR TITLE
NeoForge 1.21.1: EMI/JEI recipe viewer integration

### DIFF
--- a/NEOFORGE/1.21.1/build.gradle
+++ b/NEOFORGE/1.21.1/build.gradle
@@ -40,6 +40,19 @@ repositories {
             includeGroup "dev.architectury"
         }
     }
+
+    maven {
+        name = "BlameJared"
+        url = "https://maven.blamejared.com"
+    }
+
+    maven {
+        name = "Modrinth"
+        url = "https://api.modrinth.com/maven"
+        content {
+            includeGroup "maven.modrinth"
+        }
+    }
 }
 
 // Mojang ships Java 21 to end users starting in 1.20.5, so mods should target Java 21.
@@ -139,11 +152,11 @@ dependencies {
     //compileOnly "dev.ftb.mods:ftb-chunks-neoforge:2101.1.9"
     //runtimeOnly "dev.ftb.mods:ftb-chunks-neoforge:2101.1.9"
 
-    // The JEI API is declared for compile time use, while the full JEI artifact is used at runtime
-    // compileOnly "mezz.jei:jei-${mc_version}-common-api:${jei_version}"
-    // compileOnly "mezz.jei:jei-${mc_version}-neoforge-api:${jei_version}"
-    // We add the full version to localRuntime, not runtimeOnly, so that we do not publish a dependency on it
-    // localRuntime "mezz.jei:jei-${mc_version}-neoforge:${jei_version}"
+    // Recipe viewers (optional at runtime). EMI: full jar has API. JEI: API vs full game jar.
+    compileOnly "maven.modrinth:emi:${emi_version}"
+    compileOnly "mezz.jei:jei-${minecraft_version}-neoforge-api:${jei_version}"
+    localRuntime "maven.modrinth:emi:${emi_version}"
+    localRuntime "maven.modrinth:jei:${jei_version}"
 
     // Example mod dependency using a mod jar from ./libs with a flat dir repository
     // This maps to ./libs/coolmod-${mc_version}-${coolmod_version}.jar

--- a/NEOFORGE/1.21.1/gradle.properties
+++ b/NEOFORGE/1.21.1/gradle.properties
@@ -26,3 +26,7 @@ mod_authors=ElocinDev, Recon1991, UQuark
 mod_description=Allows to remove items!
 
 necronomicon_version_range=[1.6.0]
+
+# Optional recipe viewers (Modrinth Maven). Bump when targeting newer EMI/JEI.
+emi_version=1.1.22+1.21.1+neoforge
+jei_version=19.27.0.340

--- a/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/integration/emi/ItemObliteratorEmiPlugin.java
+++ b/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/integration/emi/ItemObliteratorEmiPlugin.java
@@ -1,0 +1,37 @@
+package elocindev.item_obliterator.neoforge.integration.emi;
+
+import dev.emi.emi.api.EmiEntrypoint;
+import dev.emi.emi.api.EmiPlugin;
+import dev.emi.emi.api.EmiRegistry;
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.stack.EmiIngredient;
+import dev.emi.emi.api.stack.EmiStack;
+import elocindev.item_obliterator.neoforge.utils.Utils;
+
+@EmiEntrypoint
+public class ItemObliteratorEmiPlugin implements EmiPlugin {
+
+    @Override
+    public void register(EmiRegistry registry) {
+        registry.removeEmiStacks(ItemObliteratorEmiPlugin::emiStackObliterated);
+        registry.removeRecipes(ItemObliteratorEmiPlugin::emiRecipeObliterated);
+    }
+
+    private static boolean emiStackObliterated(EmiStack stack) {
+        if (stack == null || stack.isEmpty()) {
+            return false;
+        }
+        return Utils.isDisabled(stack.getItemStack());
+    }
+
+    private static boolean emiRecipeObliterated(EmiRecipe recipe) {
+        for (EmiIngredient output : recipe.getOutputs()) {
+            for (EmiStack stack : output.getEmiStacks()) {
+                if (emiStackObliterated(stack)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/integration/jei/ItemObliteratorJeiPlugin.java
+++ b/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/integration/jei/ItemObliteratorJeiPlugin.java
@@ -1,0 +1,95 @@
+package elocindev.item_obliterator.neoforge.integration.jei;
+
+import elocindev.item_obliterator.neoforge.ItemObliterator;
+import elocindev.item_obliterator.neoforge.utils.Utils;
+import mezz.jei.api.IModPlugin;
+import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.constants.RecipeTypes;
+import mezz.jei.api.constants.VanillaTypes;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import mezz.jei.api.recipe.IRecipeManager;
+import mezz.jei.api.recipe.RecipeIngredientRole;
+import mezz.jei.api.recipe.RecipeType;
+import mezz.jei.api.recipe.category.IRecipeCategory;
+import mezz.jei.api.runtime.IJeiRuntime;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@JeiPlugin
+public class ItemObliteratorJeiPlugin implements IModPlugin {
+
+    private static final List<RecipeType<?>> RECIPE_TYPES_TO_SCAN = List.of(
+        RecipeTypes.CRAFTING,
+        RecipeTypes.STONECUTTING,
+        RecipeTypes.SMELTING,
+        RecipeTypes.SMOKING,
+        RecipeTypes.BLASTING,
+        RecipeTypes.CAMPFIRE_COOKING,
+        RecipeTypes.SMITHING,
+        RecipeTypes.BREWING,
+        RecipeTypes.ANVIL,
+        RecipeTypes.FUELING,
+        RecipeTypes.COMPOSTING,
+        RecipeTypes.GRINDSTONE,
+        RecipeTypes.INFORMATION
+    );
+
+    @Override
+    public ResourceLocation getPluginUid() {
+        return ResourceLocation.fromNamespaceAndPath(ItemObliterator.MODID, "jei");
+    }
+
+    @Override
+    public void onRuntimeAvailable(IJeiRuntime runtime) {
+        removeBlacklistedIngredients(runtime);
+        hideRecipesWithObliteratedOutputs(runtime);
+    }
+
+    private static void removeBlacklistedIngredients(IJeiRuntime runtime) {
+        List<ItemStack> stacks = new ArrayList<>();
+        for (String id : ItemObliterator.Config.blacklisted_items) {
+            if (id == null || id.startsWith("//") || !id.contains(":")) {
+                continue;
+            }
+            BuiltInRegistries.ITEM.getOptional(ResourceLocation.parse(id)).ifPresent(item -> stacks.add(new ItemStack(item)));
+        }
+        if (!stacks.isEmpty()) {
+            runtime.getIngredientManager().removeIngredientsAtRuntime(VanillaTypes.ITEM_STACK, stacks);
+        }
+    }
+
+    private static void hideRecipesWithObliteratedOutputs(IJeiRuntime runtime) {
+        IRecipeManager recipeManager = runtime.getRecipeManager();
+        for (RecipeType<?> type : RECIPE_TYPES_TO_SCAN) {
+            hideMatchingRecipes(recipeManager, type);
+        }
+    }
+
+    private static <T> void hideMatchingRecipes(IRecipeManager recipeManager, RecipeType<T> type) {
+        IRecipeCategory<T> category = recipeManager.getRecipeCategory(type);
+        if (category == null) {
+            return;
+        }
+        List<T> toHide = recipeManager.createRecipeLookup(type)
+            .includeHidden()
+            .get()
+            .filter(recipe -> outputsContainObliterated(recipeManager, category, recipe))
+            .toList();
+        if (!toHide.isEmpty()) {
+            recipeManager.hideRecipes(type, toHide);
+        }
+    }
+
+    private static <T> boolean outputsContainObliterated(IRecipeManager recipeManager, IRecipeCategory<T> category, T recipe) {
+        for (ITypedIngredient<?> ingredient : recipeManager.getRecipeIngredients(category, recipe).getIngredients(RecipeIngredientRole.OUTPUT)) {
+            if (ingredient.getItemStack().map(Utils::isDisabled).orElse(false)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/NEOFORGE/1.21.1/src/main/templates/META-INF/neoforge.mods.toml
+++ b/NEOFORGE/1.21.1/src/main/templates/META-INF/neoforge.mods.toml
@@ -39,3 +39,17 @@ mandatory=true
 versionRange="${necronomicon_version_range}"
 ordering="NONE"
 side="BOTH"
+
+[[dependencies.${mod_id}]]
+modId="emi"
+type="optional"
+versionRange="[1.1.0,)"
+ordering="AFTER"
+side="CLIENT"
+
+[[dependencies.${mod_id}]]
+modId="jei"
+type="optional"
+versionRange="[19.0.0,)"
+ordering="AFTER"
+side="CLIENT"


### PR DESCRIPTION
- Add EmiEntrypoint and JEI plugin to hide obliterated stacks and recipes
- Add optional CLIENT deps in mods.toml for emi/jei
- Wire EMI + JEI API/runtime via Modrinth/BlameJared Maven