### PR TITLE
NeoForge 1.21.1: match blacklisted_nbt against full stack SNBT

### DIFF
--- a/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/ItemObliterator.java
+++ b/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/ItemObliterator.java
@@ -68,7 +68,7 @@ public class ItemObliterator {
     public void onEntityJoinLevel(EntityJoinLevelEvent event) {
         if (!(event.getEntity() instanceof ItemEntity item)) return;
 
-        if (!item.getItem().isEmpty() && Utils.isDisabled(item.getItem())) {
+        if (!item.getItem().isEmpty() && Utils.isDisabled(item.getItem(), item.registryAccess())) {
             item.remove(Entity.RemovalReason.DISCARDED);
         }
     }

--- a/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/config/ConfigEntries.java
+++ b/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/config/ConfigEntries.java
@@ -40,10 +40,20 @@ public class ConfigEntries {
 	@Comment("Removes an item if it contains certain nbt tag. If the whole entry (or expression) is present, the item gets removed.")
 	@Comment("Use with caution! This is a very expensive operation and can cause lag if you have a lot of items blacklisted.")
 	@Comment("	")
+	@Comment("	 On Minecraft 1.21+, item data often lives in data components (not only minecraft:custom_data).")
+	@Comment("	 When blacklisted_nbt_match_stack_snbt is true, each pattern is also matched against the full stack SNBT")
+	@Comment("	 produced by ItemStack#save (same representation as /give and creative tooltips), so substrings like")
+	@Comment("	 template_id:\"ender_hook\" or mod component keys in bracket form can match.")
+	@Comment("	")
 	@Comment("	 Example to disable a regeneration potion: Potion:\"minecraft:regeneration\"")
 	@Comment("	")
 	@Comment("	 You can also use regular expressions by starting the value with !")
 	public List<String> blacklisted_nbt = new ArrayList<>() {{}};
+
+	@Comment("-----------------------------------------------------------")
+	@Comment("If true, each blacklisted_nbt entry is matched against the full item stack SNBT (components + count), not only CustomData.")
+	@Comment("Disable for legacy packs that relied on matching only the inner custom_data tag string, or if you need slightly less work per check.")
+	public boolean blacklisted_nbt_match_stack_snbt = true;
 
 	@Comment("-----------------------------------------------------------")
 

--- a/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/mixin/ItemEntityMixin.java
+++ b/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/mixin/ItemEntityMixin.java
@@ -16,8 +16,10 @@ public class ItemEntityMixin {
     @Inject(at = @At("TAIL"), method = "readAdditionalSaveData", cancellable = true)
     public void item_obliterator$discardItemEntities(CompoundTag nbt, CallbackInfo info) {
         ItemStack item = ((ItemEntity)(Object)this).getItem();
-        
-        if (Utils.isDisabled(item)) {
+        var self = (ItemEntity)(Object)this;
+        var registries = self.level() != null ? self.registryAccess() : null;
+
+        if (Utils.isDisabled(item, registries)) {
             ((ItemEntity)(Object)this).remove(RemovalReason.DISCARDED);
         }
     }

--- a/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/mixin/ItemGroupMixin.java
+++ b/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/mixin/ItemGroupMixin.java
@@ -21,7 +21,7 @@ public abstract class ItemGroupMixin {
 
     @Inject(method = "buildContents", at = @At(value = "RETURN"))
     private void item_obliterator_buildContents(CreativeModeTab.ItemDisplayParameters displayContext, CallbackInfo ci) {
-        displayItems.removeIf(Utils::isDisabled);
-        displayItemsSearchTab.removeIf(Utils::isDisabled);
+        displayItems.removeIf(stack -> Utils.isDisabled(stack, displayContext.holders()));
+        displayItemsSearchTab.removeIf(stack -> Utils.isDisabled(stack, displayContext.holders()));
     }
 }

--- a/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/mixin/ServerPlayerMixin.java
+++ b/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/mixin/ServerPlayerMixin.java
@@ -30,7 +30,7 @@ public class ServerPlayerMixin {
         ItemStack item = ((ServerPlayer)(Object)this).getInventory().getItem(i);
         if (item == null || item.isEmpty()) return;
 
-        if (Utils.isDisabled(item)) {
+        if (Utils.isDisabled(item, ((ServerPlayer)(Object)this).registryAccess())) {
             item.setCount(0);
             ((ServerPlayer)(Object)this).sendSystemMessage(Component.literal("This item is disabled."), true);
         }

--- a/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/utils/Utils.java
+++ b/NEOFORGE/1.21.1/src/main/java/elocindev/item_obliterator/neoforge/utils/Utils.java
@@ -1,13 +1,18 @@
 package elocindev.item_obliterator.neoforge.utils;
 
+import javax.annotation.Nullable;
+
 import elocindev.item_obliterator.neoforge.ItemObliterator;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.Tag;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.trading.MerchantOffer;
+import net.neoforged.neoforge.server.ServerLifecycleHooks;
 
 public class Utils {
 
@@ -63,21 +68,38 @@ public class Utils {
     }
 
     public static boolean isDisabled(ItemStack stack) {
+        return isDisabled(stack, null);
+    }
+
+    /**
+     * @param registryAccess registry context for encoding stack SNBT; when null, uses the current logical server when available
+     */
+    public static boolean isDisabled(ItemStack stack, @Nullable HolderLookup.Provider registryAccess) {
         if (stack == null || stack.isEmpty() || stack.is(Items.AIR)) return false;
 
-        if (stack.has(DataComponents.CUSTOM_DATA)) {
-            CustomData tag = stack.get(DataComponents.CUSTOM_DATA);
-            if (tag != null) {
-                String nbtString = tag.toString();
-                for (String blacklisted_nbt : ItemObliterator.Config.blacklisted_nbt) {
-                    if (blacklisted_nbt == null || blacklisted_nbt.startsWith("//")) continue;
+        if (!ItemObliterator.Config.blacklisted_nbt.isEmpty()) {
+            String customDataString = "";
+            if (stack.has(DataComponents.CUSTOM_DATA)) {
+                CustomData tag = stack.get(DataComponents.CUSTOM_DATA);
+                if (tag != null) {
+                    customDataString = tag.toString();
+                }
+            }
 
-                    if (nbtString.contains(blacklisted_nbt)) return true;
+            HolderLookup.Provider registries = registryAccess != null ? registryAccess : defaultRegistryAccess();
+            String stackSnbt = "";
+            if (ItemObliterator.Config.blacklisted_nbt_match_stack_snbt && registries != null) {
+                stackSnbt = encodeStackSnbt(stack, registries);
+            }
 
-                    if (blacklisted_nbt.startsWith("!")) {
-                        String regex = blacklisted_nbt.substring(1);
-                        if (nbtString.matches(regex)) return true;
-                    }
+            for (String blacklisted_nbt : ItemObliterator.Config.blacklisted_nbt) {
+                if (blacklisted_nbt == null || blacklisted_nbt.startsWith("//")) continue;
+
+                if (blacklisted_nbt.startsWith("!")) {
+                    String regex = blacklisted_nbt.substring(1);
+                    if (customDataString.matches(regex) || stackSnbt.matches(regex)) return true;
+                } else {
+                    if (customDataString.contains(blacklisted_nbt) || stackSnbt.contains(blacklisted_nbt)) return true;
                 }
             }
         }
@@ -85,11 +107,31 @@ public class Utils {
         return isDisabled(getItemId(stack.getItem()));
     }
 
+    private static String encodeStackSnbt(ItemStack stack, HolderLookup.Provider registries) {
+        try {
+            Tag tag = stack.save(registries);
+            return tag != null ? tag.toString() : "";
+        } catch (Exception e) {
+            ItemObliterator.LOGGER.debug("Item Obliterator: failed to encode stack to SNBT for blacklist check: {}", e.toString());
+            return "";
+        }
+    }
+
+    @Nullable
+    private static HolderLookup.Provider defaultRegistryAccess() {
+        var server = ServerLifecycleHooks.getCurrentServer();
+        if (server != null) {
+            return server.registryAccess();
+        }
+        return null;
+    }
+
     // Check if a MerchantOffer has blacklisted items in costs or results
     public static boolean isDisabled(MerchantOffer offer) {
-        if (isDisabled(offer.getResult())) return true;
-        if (isDisabled(offer.getBaseCostA())) return true;
-        if (offer.getCostB() != null && isDisabled(offer.getCostB())) return true;
+        HolderLookup.Provider registries = defaultRegistryAccess();
+        if (isDisabled(offer.getResult(), registries)) return true;
+        if (isDisabled(offer.getBaseCostA(), registries)) return true;
+        if (offer.getCostB() != null && isDisabled(offer.getCostB(), registries)) return true;
         return false;
     }
 


### PR DESCRIPTION
## Summary
On Minecraft 1.21+, much item data lives in **data components**, not only `minecraft:custom_data`. The existing `blacklisted_nbt` check only used `CustomData#toString()`, so patterns never matched component-only stacks.

## Changes
- Match each `blacklisted_nbt` substring (or `!` regex) against **both**:
  - `CustomData#toString()` (unchanged)
  - Full stack SNBT from `ItemStack#save(HolderLookup.Provider)` (same encoding as / give-style item data)
- New config `blacklisted_nbt_match_stack_snbt` (default `true`). Set `false` to restore legacy behavior (custom data only).
- Pass registry context from player tick, item entities, creative tab `ItemDisplayParameters#holders()`, and item entity join where available; merchant offers use server registry access.

## Scope
NeoForge **1.21.1** only (`NEOFORGE/1.21.1`).

## Testing
`./gradlew build` in `NEOFORGE/1.21.1`.